### PR TITLE
Modify AbstractEnumType to handle null choice values

### DIFF
--- a/Form/AbstractEnumType.php
+++ b/Form/AbstractEnumType.php
@@ -14,7 +14,11 @@ abstract class AbstractEnumType extends AbstractType
         $resolver->setDefaults([
             'choices_as_values' => true,
             'translation_domain' => 'enums',
-            'choice_value' => function(Enum $enum) {
+            'choice_value' => function($enum) {
+                if ($enum === null) {
+                    return null;
+                }
+                
                 return $enum->getValue();
             },
         ]);


### PR DESCRIPTION
When using the generated FormType, the following error occurred:

> Type error: Argument 1 passed to Fervo\EnumBundle\Form\AbstractEnumType::Fervo\EnumBundle\Form\{closure}() must be an instance of MyCLabs\Enum\Enum, null given

This was resolved for detecting and returning null when the enum value is null.