### PR TITLE
Splitting symfony/symfony dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/DependencyInjection/Compiler/AddDoctrineTypes.php
+++ b/DependencyInjection/Compiler/AddDoctrineTypes.php
@@ -4,7 +4,6 @@ namespace Fervo\EnumBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 class AddDoctrineTypes implements CompilerPassInterface
 {

--- a/DependencyInjection/FervoEnumExtension.php
+++ b/DependencyInjection/FervoEnumExtension.php
@@ -6,7 +6,6 @@ use Fervo\EnumBundle\FervoEnumBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -2,10 +2,7 @@
 
 namespace Fervo\EnumBundle\Doctrine;
 
-use AppBundle\Enum\CommentStatus;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\Type;
 
 abstract class AbstractEnumType extends Type

--- a/Doctrine/EnumArrayType.php
+++ b/Doctrine/EnumArrayType.php
@@ -2,10 +2,7 @@
 
 namespace Fervo\EnumBundle\Doctrine;
 
-use AppBundle\Enum\CommentStatus;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\Type;
 
 class EnumArrayType extends Type

--- a/Form/AbstractEnumType.php
+++ b/Form/AbstractEnumType.php
@@ -2,7 +2,6 @@
 
 namespace Fervo\EnumBundle\Form;
 
-use MyCLabs\Enum\Enum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/Form/EnumTypeGuesser.php
+++ b/Form/EnumTypeGuesser.php
@@ -3,7 +3,6 @@
 namespace Fervo\EnumBundle\Form;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\ORM\Mapping\MappingException as LegacyMappingException;
 use Symfony\Component\Form\FormTypeGuesserInterface;
@@ -11,9 +10,6 @@ use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Doctrine\Common\Util\ClassUtils;
 
-/**
-*
-*/
 class EnumTypeGuesser implements FormTypeGuesserInterface
 {
     protected $registry;

--- a/ParamConverter/EnumParamConverter.php
+++ b/ParamConverter/EnumParamConverter.php
@@ -8,9 +8,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use MyCLabs\Enum\Enum;
 
-/**
-* 
-*/
 class EnumParamConverter implements ParamConverterInterface
 {
     /**

--- a/Twig/EnumExtension.php
+++ b/Twig/EnumExtension.php
@@ -5,9 +5,6 @@ namespace Fervo\EnumBundle\Twig;
 use MyCLabs\Enum\Enum;
 use Symfony\Component\Translation\TranslatorInterface;
 
-/**
-* 
-*/
 class EnumExtension extends \Twig_Extension
 {
     protected $translator;

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,17 @@
     },
     "require": {
         "php": "~5.5||~7.0",
-        "symfony/symfony": "~2.8|~3.0",
+        "symfony/form": "~2.8|~3.0",
+        "symfony/framework-bundle": "~2.8|~3.0",
+        "symfony/translation": "~2.8|~3.0",
         "doctrine/doctrine-bundle": "~1.2",
         "myclabs/php-enum": "~1.3",
         "doctrine/common": "~2.4"
+    },
+    "suggest": {
+        "jms/serializer-bundle": "If you want to serialize data using JMS Serializer",
+        "sensio/framework-extra-bundle": "If you wan to use ParamConverter",
+        "twig/twig": "If you want to use enum in your Twig templates"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This is the first step to make this bundle compatible for Symfony 4.

Require `symfony/symfony` is not a good practice because this requirements depend on all Symfony components.

It's better to split it and require only components needed.