### PR TITLE
`choices_as_values` is deprecated, remove it

### DIFF
--- a/Form/AbstractEnumType.php
+++ b/Form/AbstractEnumType.php
@@ -4,6 +4,7 @@ namespace Fervo\EnumBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractEnumType extends AbstractType
@@ -11,7 +12,6 @@ abstract class AbstractEnumType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'choices_as_values' => true,
             'translation_domain' => 'enums',
             'choice_value' => function($enum) {
                 if ($enum === null) {
@@ -21,6 +21,9 @@ abstract class AbstractEnumType extends AbstractType
                 return $enum->getValue();
             },
         ]);
+        if (Kernel::VERSION_ID < 30000) {
+            $resolver->setDefault('choices_as_values', true);
+        }
     }
 
     public function getParent()


### PR DESCRIPTION
Closes #4 
According to [docs](https://symfony.com/doc/3.4/reference/forms/types/choice.html#choices-as-values) the removing will have no effect