### PR TITLE
Introducing new EnumType

### DIFF
--- a/DependencyInjection/FervoEnumExtension.php
+++ b/DependencyInjection/FervoEnumExtension.php
@@ -83,21 +83,9 @@ class FervoEnumExtension extends Extension
     {
         $namespace = sprintf('%s\\%s', $vendorNamespace, $subNamespace);
         $enumClass = substr($enumFQCN, strrpos($enumFQCN, '\\') +1);
-
-        $phpArray = [];
-        foreach ($enumFQCN::toArray() as $constant => $value) {
-            $label = sprintf('%s.%s', $config['form_type'], (string) $value);
-            $value = sprintf('%s::%s()', $enumClass, $constant);
-            $phpArray[$label] = $value;
-        }
-        $stringArray = json_encode($phpArray);
-        $stringArray = preg_replace('/":"/', '"=>"', $stringArray);
-        $stringArray = preg_replace('/"(\w+::[^"]+)"/', '$1', $stringArray);
-        $stringArray = '['.substr($stringArray, 1, -1).']';
-
         $typeClassName = $enumClass.'Type';
 
-        $classFile = $this->createFormTypeClass($typeClassName, $namespace, $stringArray, $enumFQCN);
+        $classFile = $this->createFormTypeClass($typeClassName, $namespace, $config['form_type'], $enumFQCN);
 
         $formDir = $dir.'/'.str_replace('\\', '/', $subNamespace);
         if (!is_dir($formDir)) {
@@ -109,14 +97,14 @@ class FervoEnumExtension extends Extension
         return $namespace.'\\'.$typeClassName;
     }
 
-    protected function createFormTypeClass($typeClassName, $namespace, $choices, $enumFQCN)
+    protected function createFormTypeClass($typeClassName, $namespace, $choiceLabelPrefix, $enumFQCN)
     {
         $template = file_get_contents(__DIR__.'/../Resources/FormType.php.template');
         $typeClass = strtr($template, [
             '{{namespace}}' => $namespace,
             '{{enumFQCN}}' => $enumFQCN,
             '{{typeClassName}}' => $typeClassName,
-            '{{choices}}' => $choices,
+            '{{choiceLabelPrefix}}' => $choiceLabelPrefix,
         ]);
 
         return $typeClass;

--- a/Form/AbstractEnumType.php
+++ b/Form/AbstractEnumType.php
@@ -2,6 +2,8 @@
 
 namespace Fervo\EnumBundle\Form;
 
+@trigger_error('The '.__NAMESPACE__.'\AbstractEnumType class is deprecated since version 2.1 and will be removed in 3.0. Use '.__NAMESPACE__.'\EnumType instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\HttpKernel\Kernel;

--- a/Form/EnumType.php
+++ b/Form/EnumType.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Fervo\EnumBundle\Form;
+
+use MyCLabs\Enum\Enum;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Util\StringUtil;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EnumType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'enums',
+            'choice_value' => function (Enum $enum = null) {
+                if ($enum === null) {
+                    return null;
+                }
+
+                return $enum->getValue();
+            },
+            'choice_label' => function (Options $options) {
+                return function (Enum $value) use ($options) {
+                    return sprintf('%s.%s', $options['choice_label_prefix'], $value->getValue());
+                };
+            },
+            'choice_label_prefix' => function (Options $options) {
+                return StringUtil::fqcnToBlockPrefix($options['class']);
+            },
+        ]);
+        $resolver->setRequired(['class']);
+        $resolver->setAllowedValues('class', function ($value) {
+            return is_subclass_of($value, Enum::class);
+        });
+        if (Kernel::VERSION_ID < 30000) {
+            $resolver->setDefault('choices_as_values', true);
+        }
+        if (Kernel::VERSION_ID < 30200) {
+            $resolver->setNormalizer('choices', function (OptionsResolver $resolver) {
+                return $resolver['class']::values();
+            });
+        } else {
+            $resolver->setDefault('choice_loader', function (Options $options) {
+                return new CallbackChoiceLoader(function () use ($options) {
+                    if (PHP_VERSION_ID < 70000) {
+                        return $options['class']::values();
+                    } else {
+                        return $options['class']::values();
+                    }
+                });
+            });
+        }
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ The bundle auto-generates a corresponding form type for each configured enum. Th
 
 If the underlying object of the form type is a doctrine mapped entity, the type can also be guessed by the framework. But it is a good practice to always specify the FQCN in form types.
 
+Or you can use `EnumType` with configured options:
+
+    <?php
+
+    namespace AppBundle\Form\Type;
+
+    use AppBundle\Enum\Gender;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilderInterface;
+
+    class EmployeeType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options)
+        {
+            $builder
+            	// ...
+                ->add('gender', EnumType::class, [
+                    'class' => Gender::class,
+                    'choice_label_prefix' => 'gender', // optional
+                ])
+                // ...
+            ;
+        }
+    }
+
 ### Step 7: Specify translations for the enum values
 
 The form type looks by default for the translation of the enum values in the `enums` translation domain. The translation keys are on the format `{{configured form_type name}}.{{enum constant value}}`. So going with the example the translation keys would be `gender.male` and `gender.female`.

--- a/Resources/FormType.php.template
+++ b/Resources/FormType.php.template
@@ -2,18 +2,22 @@
 
 namespace {{namespace}};
 
-use {{enumFQCN}};
-use Fervo\EnumBundle\Form\AbstractEnumType;
+use Fervo\EnumBundle\Form\EnumType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class {{typeClassName}} extends AbstractEnumType
+class {{typeClassName}} extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
-
         $resolver->setDefaults([
-            'choices' => {{choices}}
+            'class' => '{{enumFQCN}}',
+            'choice_label_prefix' => '{{choiceLabelPrefix}}',
         ]);
+    }
+
+    public function getParent()
+    {
+        return EnumType::class;
     }
 }


### PR DESCRIPTION
The goal of this PR is an ability to use common form type for enum fields. Also it simplify generated form type classes.
Someone may be embarrassed by using generated classes, which don't placed in CVS and appear only when Symfony container is compiled, also these classes can't be loaded by Composer autoloader (they can be loaded only on Symfony boot). For example, static analyzers can't find the classes and throw alert.

PS: Have you thought about about storing generated classes in project src directory?