### PR TITLE
Modify Doctrine type commented values to remove deprecation notices.

### DIFF
--- a/DependencyInjection/Compiler/AddDoctrineTypes.php
+++ b/DependencyInjection/Compiler/AddDoctrineTypes.php
@@ -19,7 +19,7 @@ class AddDoctrineTypes implements CompilerPassInterface
         $types = $container->getParameter('doctrine.dbal.connection_factory.types');
         $enumTypes = $container->getParameter('fervo_enum.doctrine_type_classes');
         $arrayType = ['enumarray' => [
-            'commented' => true,
+            'commented' => false,
             'class' => 'Fervo\EnumBundle\Doctrine\EnumArrayType',
         ]];
 

--- a/DependencyInjection/FervoEnumExtension.php
+++ b/DependencyInjection/FervoEnumExtension.php
@@ -36,7 +36,7 @@ class FervoEnumExtension extends Extension
         $doctrineFormMap = [];
         $enumMap = [];
         foreach ($config['enums'] as $className => $classConfig) {
-            $enumTypeClasses[$classConfig['doctrine_type']] = ['commented' => true, 'class' => $this->writeTypeClassFile($className, $classConfig, FervoEnumBundle::VENDOR_NAMESPACE, FervoEnumBundle::DOCTRINE_NAMESPACE, $generatedDir)];
+            $enumTypeClasses[$classConfig['doctrine_type']] = ['commented' => null, 'class' => $this->writeTypeClassFile($className, $classConfig, FervoEnumBundle::VENDOR_NAMESPACE, FervoEnumBundle::DOCTRINE_NAMESPACE, $generatedDir)];
             $formTypeClasses[$classConfig['form_type']] = ['class' => $this->writeFormTypeClassFile($className, $classConfig, FervoEnumBundle::VENDOR_NAMESPACE, FervoEnumBundle::FORM_NAMESPACE, $generatedDir)];
             $doctrineFormMap[$classConfig['form_type']] = $classConfig['doctrine_type'];
             $enumMap[$className] = $classConfig['form_type'];

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -33,4 +33,9 @@ abstract class AbstractEnumType extends Type
 
         return $value->getValue();
     }
+    
+    public function requiresSQLCommentHint(AbstractPlatform $platform) : bool
+    {
+        return true;
+    }
 }

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -36,6 +36,6 @@ abstract class AbstractEnumType extends Type
     
     public function requiresSQLCommentHint(AbstractPlatform $platform) : bool
     {
-        return true;
+        return false;
     }
 }

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -36,6 +36,6 @@ abstract class AbstractEnumType extends Type
     
     public function requiresSQLCommentHint(AbstractPlatform $platform) : bool
     {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
Magnus,

There are deprecation notices in Doctrine's AbstractEnumType that want the `commented` configuration option to be removed. I don't know I entirely follow what Doctrine wants, however two of the changes (to `null` in the extension configuration and `false` in `enumArray`) swap the values from `true` to `null` in the extension and `false` in `enumArray`. The other change is a method on `AbstractEnumType` for defaulting the commented type option to false (commits 7a72504 and 
def2d4d). 

Thanks!
Jared