### PR TITLE
Enable DoctrineBundle 2.0

### DIFF
--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -22,6 +22,13 @@ abstract class AbstractEnumType extends Type
 
         $enumClass = $this->getEnumClass();
 
+        // If the enumeration provides a casting method, apply it
+        if (method_exists($enumClass, 'castValueIn')) {
+            /** @var callable $castValueIn */
+            $castValueIn = [$enumClass, 'castValueIn'];
+            $value = $castValueIn($value);
+        }
+
         return new $enumClass($value);
     }
 
@@ -29,6 +36,15 @@ abstract class AbstractEnumType extends Type
     {
         if ($value == null) {
             return null;
+        }
+
+        $enumClass = $this->getEnumClass();
+
+        // If the enumeration provides a casting method, apply it
+        if (method_exists($enumClass, 'castValueOut')) {
+            /** @var callable $castValueOut */
+            $castValueOut = [$enumClass, 'castValueOut'];
+            return $castValueOut($value->getValue());
         }
 
         return $value->getValue();

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -49,4 +49,8 @@ abstract class AbstractEnumType extends Type
 
         return $value->getValue();
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform) {
+        return true;
+    }
 }

--- a/Doctrine/EnumArrayType.php
+++ b/Doctrine/EnumArrayType.php
@@ -56,4 +56,8 @@ class EnumArrayType extends Type
     {
         return 'enumarray';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform) {
+        return true;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ The form type looks by default for the translation of the enum values in the `en
         // ...
     }
 
+### Customize value casting
+
+In case the values of your enumeration are not strings, you can use the two magic function `castValueIn` and `castValueOut` to support non-string values:
+
+```php
+<?php
+
+namespace App\Enum;
+
+use MyCLabs\Enum\Enum;
+
+class Status extends Enum {
+    public const SUCCESS = 1;
+    public const ERROR = 2;
+    
+    public static function castValueIn($value) {
+        return (int) $value;
+    }
+}
+```
+
 [myclabs-enum-homepage]: https://github.com/myclabs/php-enum
 [jms-serializer-homepage]: http://jmsyst.com/libs/serializer
 [symfony-forms-homepage]: http://symfony.com/doc/current/book/forms.html

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/form": "~2.8|~3.0|~4.0",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
-        "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/doctrine-bundle": "~1.2|~2.0",
         "myclabs/php-enum": "~1.3",
         "doctrine/common": "~2.4"
     },


### PR DESCRIPTION
Fixes deprecation message for DoctrineBundle 2.0 and also enables it in `composer.json`