### PR TITLE
Drop Symfony 2.8

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('fervo_enum');
+        $treeBuilder = new TreeBuilder('fervo_enum');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('fervo_enum');
+        }
 
         $rootNode
             ->children()

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -22,6 +22,13 @@ abstract class AbstractEnumType extends Type
 
         $enumClass = $this->getEnumClass();
 
+        // If the enumeration provides a casting method, apply it
+        if (method_exists($enumClass, 'castValueIn')) {
+            /** @var callable $castValueIn */
+            $castValueIn = [$enumClass, 'castValueIn'];
+            $value = $castValueIn($value);
+        }
+
         return new $enumClass($value);
     }
 
@@ -29,6 +36,15 @@ abstract class AbstractEnumType extends Type
     {
         if ($value == null) {
             return null;
+        }
+
+        $enumClass = $this->getEnumClass();
+
+        // If the enumeration provides a casting method, apply it
+        if (method_exists($enumClass, 'castValueOut')) {
+            /** @var callable $castValueOut */
+            $castValueOut = [$enumClass, 'castValueOut'];
+            return $castValueOut($value->getValue());
         }
 
         return $value->getValue();

--- a/Doctrine/AbstractEnumType.php
+++ b/Doctrine/AbstractEnumType.php
@@ -49,4 +49,8 @@ abstract class AbstractEnumType extends Type
 
         return $value->getValue();
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform) {
+        return true;
+    }
 }

--- a/Doctrine/EnumArrayType.php
+++ b/Doctrine/EnumArrayType.php
@@ -56,4 +56,8 @@ class EnumArrayType extends Type
     {
         return 'enumarray';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform) {
+        return true;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ The form type looks by default for the translation of the enum values in the `en
         // ...
     }
 
+### Customize value casting
+
+In case the values of your enumeration are not strings, you can use the two magic function `castValueIn` and `castValueOut` to support non-string values:
+
+```php
+<?php
+
+namespace App\Enum;
+
+use MyCLabs\Enum\Enum;
+
+class Status extends Enum {
+    public const SUCCESS = 1;
+    public const ERROR = 2;
+    
+    public static function castValueIn($value) {
+        return (int) $value;
+    }
+}
+```
+
 [myclabs-enum-homepage]: https://github.com/myclabs/php-enum
 [jms-serializer-homepage]: http://jmsyst.com/libs/serializer
 [symfony-forms-homepage]: http://symfony.com/doc/current/book/forms.html

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/form": "~2.8|~3.0|~4.0",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
-        "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/doctrine-bundle": "~1.2|~2.0",
         "myclabs/php-enum": "~1.3",
         "doctrine/common": "~2.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
         "psr-4": { "Fervo\\EnumBundle\\": ""}
     },
     "require": {
-        "php": "~5.5||~7.0",
-        "symfony/form": "~2.8|~3.0|~4.0",
-        "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-        "symfony/translation": "~2.8|~3.0|~4.0",
-        "doctrine/doctrine-bundle": "~1.2|~2.0",
-        "myclabs/php-enum": "~1.3",
-        "doctrine/common": "~2.4"
+        "php": "^7.1",
+        "symfony/form": "^3.4|^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/translation": "^3.4|^4.0",
+        "doctrine/doctrine-bundle": "^1.2|^2.0",
+        "myclabs/php-enum": "^1.3",
+        "doctrine/common": "^2.4"
     },
     "suggest": {
         "jms/serializer-bundle": "If you want to serialize data using JMS Serializer",


### PR DESCRIPTION
Drops Symfony 2.8 as it is not maintained anymore. Also prepares for Symfony 5 as it uses the new `TreeBulder` constructor (and thus resolving the deprecation message starting from SF4.3)