### PR TITLE
Upgrade symfony5

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('fervo_enum');
+        $treeBuilder = new TreeBuilder('fervo_enum');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('fervo_enum');
+        }
 
         $rootNode
             ->children()

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     },
     "require": {
         "php": "~5.5||~7.0",
-        "symfony/form": "~2.8|~3.0|~4.0",
-        "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-        "symfony/translation": "~2.8|~3.0|~4.0",
+        "symfony/form": "~3.0|~4.0",
+        "symfony/framework-bundle": "~3.0|~4.0",
+        "symfony/translation": "~3.0|~4.0",
         "doctrine/doctrine-bundle": "~1.2",
         "myclabs/php-enum": "~1.3",
         "doctrine/common": "~2.4"

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     },
     "require": {
         "php": "~5.5||~7.0",
-        "symfony/form": "~3.0|~4.0",
-        "symfony/framework-bundle": "~3.0|~4.0",
-        "symfony/translation": "~3.0|~4.0",
+        "symfony/form": "~3.0|~4.0|~5.0",
+        "symfony/framework-bundle": "~3.0|~4.0|~5.0",
+        "symfony/translation": "~3.0|~4.0|~5.0",
         "doctrine/doctrine-bundle": "~1.2",
         "myclabs/php-enum": "~1.3",
         "doctrine/common": "~2.4"


### PR DESCRIPTION
This PR enables this bundle to be used with Symfony 5. It also removes the deprecation messages in Symfony 4.4 (see #16).

Note: this must be merged after #19 