### PR TITLE
Fix php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "psr-4": { "Fervo\\EnumBundle\\": ""}
     },
     "require": {
-        "php": "~5.5||~7.0",
+        "php": "~7.0",
         "symfony/form": "~3.0|~4.0|~5.0",
         "symfony/framework-bundle": "~3.0|~4.0|~5.0",
         "symfony/translation": "~3.0|~4.0|~5.0",


### PR DESCRIPTION
Due to the usage of scalar types, the bundle is not compatible anymore with php < 7