### PR TITLE
Use configured value for choice label prefix instead of a string created from FQCN

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,9 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->booleanNode('fqcn_choice_label_prefix')
+                    ->defaultTrue()
+                ->end()
                 ->arrayNode('enums')
                     ->useAttributeAsKey('class')
                     ->prototype('array')

--- a/DependencyInjection/FervoEnumExtension.php
+++ b/DependencyInjection/FervoEnumExtension.php
@@ -44,10 +44,15 @@ class FervoEnumExtension extends Extension
             $enumHandlerDef->addTag('jms_serializer.handler', ['type' => $className, 'format' => 'json', 'method' => 'serializeEnumToJson']);
         }
 
+        if ($config['fqcn_choice_label_prefix']) {
+            @trigger_error('Using the default value (true) for fqcn_choice_label_prefix is deprecated. Please change it to false and check that your translations in choice types are still correct.', E_USER_DEPRECATED);
+        }
+
         $container->setParameter('fervo_enum.doctrine_type_classes', $enumTypeClasses);
         $container->setParameter('fervo_enum.form_type_classes', $formTypeClasses);
         $container->setParameter('fervo_enum.doctrine_form_map', $doctrineFormMap);
         $container->setParameter('fervo_enum.enum_map', $enumMap);
+        $container->setParameter('fervo_enum.fqcn_choice_label_prefix', $config['fqcn_choice_label_prefix']);
     }
 
     protected function writeTypeClassFile($className, $config, $vendorNamespace, $subNamespace, $dir)

--- a/Form/EnumType.php
+++ b/Form/EnumType.php
@@ -13,6 +13,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EnumType extends AbstractType
 {
+    private $enumMap;
+    private $fqcnChoicePrefix;
+
+    public function __construct(array $enumMap, bool $fqcnChoicePrefix)
+    {
+        $this->enumMap = $enumMap;
+        $this->fqcnChoicePrefix = $fqcnChoicePrefix;
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -30,7 +39,16 @@ class EnumType extends AbstractType
                 };
             },
             'choice_label_prefix' => function (Options $options) {
-                return StringUtil::fqcnToBlockPrefix($options['class']);
+                // BC compatibility layer, to be removed in 3.0
+                if ($this->fqcnChoicePrefix) {
+                    return StringUtil::fqcnToBlockPrefix($options['class']);
+                }
+
+                if (!isset($this->enumMap[$options['class']])) {
+                    throw new \LogicException(sprintf('No prefix found for class %s', $options['class']));
+                }
+
+                return $this->enumMap[$options['class']];
             },
         ]);
         $resolver->setRequired(['class']);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Provides a [MyCLabs\Enum][myclabs-enum-homepage] integration with Doctrine for y
 ### Step 3: Configure your enum
 
     fervo_enum:
+        fqcn_choice_label_prefix: true  # For Backward compatibily, should be explicitely set to true
         enums:
             AppBundle\Enum\Gender:
                 doctrine_type: gender # Type name used in doctrine annotations

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,3 +25,12 @@ services:
         class: Fervo\EnumBundle\ParamConverter\EnumParamConverter
         tags:
             - { name: request.param_converter, converter: enum }
+
+    fervo_enum.enum_type:
+        class: Fervo\EnumBundle\Form\EnumType
+        arguments:
+          - "%fervo_enum.enum_map%"
+          - "%fervo_enum.fqcn_choice_label_prefix%"
+        tags:
+            - { name: form.type }
+


### PR DESCRIPTION
The prefix in choice label is currently deducted from the enum class FQCN. In Twig templates it's the value configured in `fervo_enum.form_type` that is used.

This PR aims to standardize that using `fervo_enum.form_type` everywhere.

A backward compatibility layer is added too to not break translations of existing applications.